### PR TITLE
fix: 时钟显示问题

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -242,7 +242,7 @@ function onBeforeUnload(event) {
       <template v-else-if="isFailed">😭</template>
       <template v-else>🎮</template>
     </button>
-    <span class="w-32 justify-end countdown"><span :style="{'--value': timeCount}"></span></span>
+    <span class="w-32 justify-end countdown"><span :style="{'--value': Math.floor(timeCount / 60)}"></span>:<span :style="{'--value': timeCount % 60}"></span></span>
   </div>
   <div v-if="grid" id="stage" :class="{'pointer-events-none': !isStart}" :style="gridStyle" @contextmenu.stop.prevent>
     <grid-item

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,6 +17,11 @@ const column = ref(Levels[level.value].column);
 const flagged = ref(0); // 标记的数量
 const opened = ref(0); // 点开的数量
 const timeCount = ref(0);
+// 时间计数样式(nil为默认样式，ez为简单样式)
+const timeCountStyle = computed(() => Levels[level.value].timeCountStyle || 'nil');
+// 超时时间 (如undefine则为60分钟)
+const timeout = computed(() => Levels[level.value].timeout || 60 * 60);
+
 // 格子总数
 const total = computed(() => {
   return row.value * column.value;
@@ -91,6 +96,10 @@ function doRealStart(clickedIndex) {
   });
   interval = setInterval(() => {
     timeCount.value += 1;
+    if(timeCount.value >= timeout.value) {
+      doStop();
+      alert('时间到！');
+    }
   }, 1000);
   // 防止用户错误离开
   addEventListener('beforeunload', onBeforeUnload);
@@ -242,7 +251,15 @@ function onBeforeUnload(event) {
       <template v-else-if="isFailed">😭</template>
       <template v-else>🎮</template>
     </button>
-    <span class="w-32 justify-end countdown"><span :style="{'--value': Math.floor(timeCount / 60)}"></span>:<span :style="{'--value': timeCount % 60}"></span></span>
+    <span class="w-32 justify-end countdown">
+    <template v-if="timeCountStyle === 'nil'">
+      
+      <span :style="{'--value': Math.floor(timeCount / 60)}"></span>:<span :style="{'--value': timeCount % 60}"></span>
+    </template>
+    <template v-else-if="timeCountStyle === 'ez'">
+      <span :style="{'--value': timeCount}"></span>
+    </template>
+    </span>
   </div>
   <div v-if="grid" id="stage" :class="{'pointer-events-none': !isStart}" :style="gridStyle" @contextmenu.stop.prevent>
     <grid-item

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -3,6 +3,9 @@ export const Levels = {
     row: 9,
     column: 9,
     bomb: 10,
+    timeCountStyle:'ez',
+    // 超时时间
+    timeout: 99
   },
   Medium: {
     row: 16,


### PR DESCRIPTION
这个PR是针对issues #3 的。
### 问题描述

当前时间显示逻辑仅支持秒数，当时间超过 99 秒时，数字会消失，影响用户体验。

### 技术选型

此问题比较简单，对于给定的timeCount（表示秒数）变量，可以用除法和求模运算计算其分钟和时间。

### 技术细节

修改前，由于daisy UI的限制，countdown组件[(Countdown)](https://daisyui.com/components/countdown/)至多显示到99，因此无法显示超过99的秒数。修改后，由于将秒数换算成分钟和秒数，这样秒数就不会超过60，更加不会超过99。

潜在问题：分钟超过99分钟后仍然无法显示。考虑到玩家游玩时间极少达到1小时，可忽略。也可以通过增加游玩时间限制，避免玩家无限游玩、挂机。

同时，没有引入其他变量和逻辑，仅修改了原有代码的表现层，尽可能减少潜在的问题。

### 效果截图


https://github.com/user-attachments/assets/54100ed9-3792-4804-8df0-684b9d99b2b0



![image](https://github.com/user-attachments/assets/72c9e00c-884a-47d7-963e-d601cdb8aeb5)


