### PR TITLE
超时判负 & 显示优化

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -242,7 +242,7 @@ function onBeforeUnload(event) {
       <template v-else-if="isFailed">😭</template>
       <template v-else>🎮</template>
     </button>
-    <span class="w-32 justify-end countdown"><span :style="{'--value': timeCount}"></span></span>
+    <span class="w-32 justify-end countdown"><span :style="{'--value': Math.floor(timeCount / 60)}"></span>:<span :style="{'--value': timeCount % 60}"></span></span>
   </div>
   <div v-if="grid" id="stage" :class="{'pointer-events-none': !isStart}" :style="gridStyle" @contextmenu.stop.prevent>
     <grid-item

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,6 +17,11 @@ const column = ref(Levels[level.value].column);
 const flagged = ref(0); // 标记的数量
 const opened = ref(0); // 点开的数量
 const timeCount = ref(0);
+// 时间计数样式(nil为默认样式，ez为简单样式)
+const timeCountStyle = computed(() => Levels[level.value].timeCountStyle || 'nil');
+// 超时时间 (如undefine则为60分钟)
+const timeout = computed(() => Levels[level.value].timeout || 60 * 60);
+
 // 格子总数
 const total = computed(() => {
   return row.value * column.value;
@@ -91,6 +96,10 @@ function doRealStart(clickedIndex) {
   });
   interval = setInterval(() => {
     timeCount.value += 1;
+    if(timeCount.value >= timeout.value) {
+      doStop();
+      alert('时间到！');
+    }
   }, 1000);
   // 防止用户错误离开
   addEventListener('beforeunload', onBeforeUnload);
@@ -242,7 +251,15 @@ function onBeforeUnload(event) {
       <template v-else-if="isFailed">😭</template>
       <template v-else>🎮</template>
     </button>
-    <span class="w-32 justify-end countdown"><span :style="{'--value': Math.floor(timeCount / 60)}"></span>:<span :style="{'--value': timeCount % 60}"></span></span>
+    <span class="w-32 justify-end countdown">
+    <template v-if="timeCountStyle === 'nil'">
+      
+      <span :style="{'--value': Math.floor(timeCount / 60)}"></span>:<span :style="{'--value': timeCount % 60}"></span>
+    </template>
+    <template v-else-if="timeCountStyle === 'ez'">
+      <span :style="{'--value': timeCount}"></span>
+    </template>
+    </span>
   </div>
   <div v-if="grid" id="stage" :class="{'pointer-events-none': !isStart}" :style="gridStyle" @contextmenu.stop.prevent>
     <grid-item

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -3,6 +3,9 @@ export const Levels = {
     row: 9,
     column: 9,
     bomb: 10,
+    timeCountStyle:'ez',
+    // 超时时间
+    timeout: 99
   },
   Medium: {
     row: 16,


### PR DESCRIPTION
为解决PR #4 存在的问题，创建此PR。

### 问题描述
有个问题，对于小型地图，其实 99 秒足够了，但是你这样会一直显示 0:xx，其实体验也不好。

### 技术选型和细节
针对不同的Level，在数据库中增加新键timeout和timeCountStyle，表示Level所需的超时判负时间和时间显示样式。

因此可以在Easy模式中，直接展示秒数，并且实现超时判负。

其余逻辑与PR #4 相同。

![image](https://github.com/user-attachments/assets/44af4fc5-8d6a-4cbb-a34a-2e0dacc049b8)
![image](https://github.com/user-attachments/assets/458cb34a-2732-4420-a466-58d4faf3891a)
