### PR TITLE
fix: 修复时间显示

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,10 +17,6 @@ const column = ref(Levels[level.value].column);
 const flagged = ref(0); // 标记的数量
 const opened = ref(0); // 点开的数量
 const timeCount = ref(0);
-// 时间计数样式(nil为默认样式，ez为简单样式)
-const timeCountStyle = computed(() => Levels[level.value].timeCountStyle || 'nil');
-// 超时时间 (如undefine则为60分钟)
-const timeout = computed(() => Levels[level.value].timeout || 60 * 60);
 
 // 格子总数
 const total = computed(() => {
@@ -96,10 +92,6 @@ function doRealStart(clickedIndex) {
   });
   interval = setInterval(() => {
     timeCount.value += 1;
-    if(timeCount.value >= timeout.value) {
-      doStop();
-      alert('时间到！');
-    }
   }, 1000);
   // 防止用户错误离开
   addEventListener('beforeunload', onBeforeUnload);

--- a/src/App.vue
+++ b/src/App.vue
@@ -244,13 +244,13 @@ function onBeforeUnload(event) {
       <template v-else>🎮</template>
     </button>
     <span class="w-32 justify-end countdown">
-      <template v-if="timeCount <= 99">
+      <template v-if="timeCount <= 59">
         <span :style="{ '--value': timeCount }"></span>
       </template>
       <template v-else-if="timeCount >= 99 * 60 + 59">
         <span style="--value:99"></span>
         :
-        <span style="--value:59"></span>
+        <span :style="{ '--value': timeCount % 60 }"></span>
       </template>
       <template v-else>
         <span :style="{ '--value': Math.floor(timeCount / 60) }"></span>

--- a/src/App.vue
+++ b/src/App.vue
@@ -244,7 +244,7 @@ function onBeforeUnload(event) {
       <template v-else>🎮</template>
     </button>
     <span class="w-32 justify-end countdown">
-      <template v-if="timeCount <= 10">
+      <template v-if="timeCount <= 99">
         <span :style="{ '--value': timeCount }"></span>
       </template>
       <template v-else-if="timeCount >= 99 * 60 + 59">

--- a/src/App.vue
+++ b/src/App.vue
@@ -242,7 +242,7 @@ function onBeforeUnload(event) {
       <template v-else-if="isFailed">😭</template>
       <template v-else>🎮</template>
     </button>
-    <span class="w-32 justify-end countdown"><span :style="{'--value': timeCount}"></span></span>
+    <span class="w-32 justify-end countdown"><span :style="{'--value': Math.floor(timeCount / 60)}"></span>:<span :style="{'--value': timeCount % 60}"></span></span>
   </div>
   <div v-if="grid" id="stage" :class="{'pointer-events-none': !isStart}" :style="gridStyle" @contextmenu.stop.prevent>
     <grid-item

--- a/src/App.vue
+++ b/src/App.vue
@@ -223,7 +223,7 @@ function onBeforeUnload(event) {
                 />
                 <span>
                 <i class="bi mr-2" :class="level === key ? 'bi-check-lg' : 'bi-blank'" /> {{key}}
-              </span>
+                </span>
               </label>
             </li>
           </ul>
@@ -242,7 +242,21 @@ function onBeforeUnload(event) {
       <template v-else-if="isFailed">😭</template>
       <template v-else>🎮</template>
     </button>
-    <span class="w-32 justify-end countdown"><span :style="{'--value': Math.floor(timeCount / 60)}"></span>:<span :style="{'--value': timeCount % 60}"></span></span>
+    <span class="w-32 justify-end countdown">
+      <template v-if="timeCount <= 10">
+        <span :style="{ '--value': timeCount }"></span>
+      </template>
+      <template v-else-if="timeCount >= 99 * 60 + 59">
+        <span style="--value:99"></span>
+        :
+        <span style="--value:59"></span>
+      </template>
+      <template v-else>
+        <span :style="{ '--value': Math.floor(timeCount / 60) }"></span>
+        :
+        <span :style="{ '--value': timeCount % 60 }"></span>
+      </template>
+    </span>
   </div>
   <div v-if="grid" id="stage" :class="{'pointer-events-none': !isStart}" :style="gridStyle" @contextmenu.stop.prevent>
     <grid-item

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,6 +17,11 @@ const column = ref(Levels[level.value].column);
 const flagged = ref(0); // 标记的数量
 const opened = ref(0); // 点开的数量
 const timeCount = ref(0);
+// 时间计数样式(nil为默认样式，ez为简单样式)
+const timeCountStyle = computed(() => Levels[level.value].timeCountStyle || 'nil');
+// 超时时间 (如undefine则为60分钟)
+const timeout = computed(() => Levels[level.value].timeout || 60 * 60);
+
 // 格子总数
 const total = computed(() => {
   return row.value * column.value;
@@ -91,6 +96,10 @@ function doRealStart(clickedIndex) {
   });
   interval = setInterval(() => {
     timeCount.value += 1;
+    if(timeCount.value >= timeout.value) {
+      doStop();
+      alert('时间到！');
+    }
   }, 1000);
   // 防止用户错误离开
   addEventListener('beforeunload', onBeforeUnload);
@@ -242,7 +251,15 @@ function onBeforeUnload(event) {
       <template v-else-if="isFailed">😭</template>
       <template v-else>🎮</template>
     </button>
-    <span class="w-32 justify-end countdown"><span :style="{'--value': Math.floor(timeCount / 60)}"></span>:<span :style="{'--value': timeCount % 60}"></span></span>
+    <span class="w-32 justify-end countdown">
+    <template v-if="timeCountStyle === 'nil'">
+      
+      <span :style="{'--value': Math.floor(timeCount / 60)}"></span>:<span :style="{'--value': timeCount % 60}"></span>
+    </template>
+    <template v-else-if="timeCountStyle === 'ez'">
+      <span :style="{'--value': timeCount}"></span>
+    </template>
+    </span>
   </div>
   <div v-if="grid" id="stage" :class="{'pointer-events-none': !isStart}" :style="gridStyle" @contextmenu.stop.prevent>
     <grid-item

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -3,6 +3,9 @@ export const Levels = {
     row: 9,
     column: 9,
     bomb: 10,
+    timeCountStyle:'ez',
+    // 超时时间
+    timeout: 99
   },
   Medium: {
     row: 16,

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -3,9 +3,6 @@ export const Levels = {
     row: 9,
     column: 9,
     bomb: 10,
-    timeCountStyle:'ez',
-    // 超时时间
-    timeout: 99
   },
   Medium: {
     row: 16,


### PR DESCRIPTION
### 描述

①添加了 分钟：秒数 显示，仅当时间大于99秒时
②仅显示 秒数，当时间小于等于99秒时
③时间将会在 99 : 59 冻结

### 效果
![image](https://github.com/user-attachments/assets/90f26532-8245-4124-811f-30a74a2feb9b)
![image](https://github.com/user-attachments/assets/db738923-8d0a-4a9e-9a79-30d560c9a2ee)
